### PR TITLE
First addition to aggregate

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
 aggregate_branch: 3.12
+aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ test:
 
 about:
   home: https://github.com/python/typeshed
+  description: Typing stubs for setuptools
   dev_url: https://github.com/python/typeshed
   doc_url: https://typing.readthedocs.io/
   summary: Typing stubs for setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,13 +26,21 @@ requirements:
 
 test:
   commands:
-    - test -f $SP_DIR/pkg_resources-stubs/__init__.pyi
+    - test -f $SP_DIR/pkg_resources-stubs/__init__.pyi # [unix]
+    - if not exist %SP_DIR%\\pkg_resources-stubs\\__init__.pyi exit 1 # [win]
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/python/typeshed
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://typing.readthedocs.io/
   summary: Typing stubs for setuptools
   license: Apache-2.0 AND MIT
   license_file: LICENSE
+  license_family: Other
+
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,12 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
+  imports:
+    - setuptools
   commands:
+    - pip check
     - test -f $SP_DIR/pkg_resources-stubs/__init__.pyi # [unix]
     - if not exist %SP_DIR%\\pkg_resources-stubs\\__init__.pyi exit 1 # [win]
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,6 @@ test:
     - test -f $SP_DIR/pkg_resources-stubs/__init__.pyi # [unix]
     - if not exist %SP_DIR%\\pkg_resources-stubs\\__init__.pyi exit 1 # [win]
     - pip check
-  requires:
-    - pip
 
 about:
   home: https://github.com/python/typeshed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "67.2.0.1" %}
+{% set version = "69.0.0.20240125" %}
 
 package:
   name: types-setuptools
@@ -8,20 +8,19 @@ source:
   - url: https://raw.githubusercontent.com/python/typeshed/main/LICENSE
     sha256: 295f8538c94ae5c3043301cf7cff1c852dab6a786a8ddee471e061b40d5ecabe
   - url: https://pypi.io/packages/source/t/types-setuptools/types-setuptools-{{ version }}.tar.gz
-    sha256: 07648088bc2cbf0f2745107d394e619ba2a747f68a5904e6e4089c0cb8322065
+    sha256: 22ad498cb585b22ce8c97ada1fccdf294a2e0dd7dc984a28535a84ea82f45b3f
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true # [py<36]
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
   run:
-    - python >=3.6
-    - types-docutils
+    - python
 
 test:
   commands:


### PR DESCRIPTION
types-setuptools 69.0.0.20240125
**Destination channel:** main

### Links

- [{PKG-4071}](PKG-4071) 
- [Upstream repository](https://github.com/python/typeshed/tree/main/stubs/setuptools)

### Explanation of changes:
- added abs.yaml for 3.12 because why not
- Updated version and hashes
- Removed no-arch
- Added no-deps and no-build-isolation